### PR TITLE
fix: change "I knew" to "Acknowledge"

### DIFF
--- a/src/i18n/Overview.js
+++ b/src/i18n/Overview.js
@@ -306,7 +306,7 @@ export default {
   },
   konw: {
     zh: '知道了',
-    en: 'I knew',
+    en: 'Acknowledge',
   },
   expired: {
     zh: '过期',


### PR DESCRIPTION
This is the acknowledgement button of the license warning.
"I knew" is a direct translation from Chinese "知道了“ (past tense).